### PR TITLE
chore: release v0.3.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "color-ssh"
 description = "A Rust-based SSH client with syntax highlighting."
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 authors = ["Karsyboy"]
 documentation = "https://github.com/karsyboy/color-ssh"


### PR DESCRIPTION



## 🤖 New release

* `color-ssh`: 0.3.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [v0.3.9] - 2025-02-03

### 🚀 Features

- Added homebrew support using repo karsyboy/homebrew-tap

### 🐛 Bug Fixes

- Updated version to latest pending release version

### 🎨 Styling

- Updated github release badge

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).