### PR TITLE
chore: release v0.3.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "color-ssh"
 description = "A Rust-based SSH client with syntax highlighting."
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 authors = ["Karsyboy"]
 documentation = "https://github.com/karsyboy/color-ssh"


### PR DESCRIPTION



## 🤖 New release

* `color-ssh`: 0.3.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [v0.3.9] - 2025-02-04

### 🚀 Features

- Added homebrew support using repo karsyboy/homebrew-tap

### 🐛 Bug Fixes

- Updated version to latest pending release version
- Removed windows arm64 support as it does not work with the updater.
- Fixed versioning

### 💼 Other

- Revert "chore: release v0.3.10 (#11)" (#12)

This reverts commit 9f0495eb1d51e95a12bea91761516b504df0ba5e.

### 🎨 Styling

- Updated github release badge

### ⚙️ Miscellaneous Tasks

- Release v0.3.9 (#10)
- Release v0.3.10 (#11)
- Release v0.3.9 (#13)

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).